### PR TITLE
check for CATKIN_ENABLE_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,10 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 add_library(laser_geometry src/laser_geometry.cpp)
 target_link_libraries(laser_geometry ${Boost_LIBRARIES} ${tf_LIBRARIES})
 
-catkin_add_gtest(projection_test test/projection_test.cpp)
-target_link_libraries(projection_test laser_geometry)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_gtest(projection_test test/projection_test.cpp)
+  target_link_libraries(projection_test laser_geometry)
+endif()
 
 install(TARGETS laser_geometry
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
 
   <url>http://ros.org/wiki/laser_geometry</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roscpp</build_depend>


### PR DESCRIPTION
Since version 0.5.68, catkin provides to optionally configure tests. This commit adjusts the CMakeLists.txt to opt-in the tests.
