### PR TITLE
Fix exception due to neg. duration when laserscan ranges[] is empty

### DIFF
--- a/src/laser_geometry.cpp
+++ b/src/laser_geometry.cpp
@@ -211,7 +211,8 @@ const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(do
 
     // Extract transforms for the beginning and end of the laser scan
     ros::Time start_time = scan_in.header.stamp ;
-    ros::Time end_time   = scan_in.header.stamp + ros::Duration().fromSec( (scan_in.ranges.size()-1) * scan_in.time_increment);
+    ros::Time end_time   = scan_in.header.stamp ;
+    if(!scan_in.ranges.empty()) end_time += ros::Duration().fromSec( (scan_in.ranges.size()-1) * scan_in.time_increment);
 
     tf::StampedTransform start_transform ;
     tf::StampedTransform end_transform ;
@@ -656,7 +657,8 @@ const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(do
                                                          int channel_options)
   {
     ros::Time start_time = scan_in.header.stamp;
-    ros::Time end_time   = scan_in.header.stamp + ros::Duration ().fromSec ( (scan_in.ranges.size()-1) * scan_in.time_increment);
+    ros::Time end_time   = scan_in.header.stamp;
+    if(!scan_in.ranges.empty()) end_time += ros::Duration ().fromSec ( (scan_in.ranges.size()-1) * scan_in.time_increment);
 
     tf::StampedTransform start_transform, end_transform ;
 
@@ -690,7 +692,8 @@ const boost::numeric::ublas::matrix<double>& LaserProjection::getUnitVectors_(do
                                                          int channel_options)
   {
     ros::Time start_time = scan_in.header.stamp;
-    ros::Time end_time   = scan_in.header.stamp + ros::Duration ().fromSec ( (scan_in.ranges.size()-1) * scan_in.time_increment);
+    ros::Time end_time   = scan_in.header.stamp;
+    if(!scan_in.ranges.empty()) end_time += ros::Duration ().fromSec ( (scan_in.ranges.size()-1) * scan_in.time_increment);
 
     geometry_msgs::TransformStamped start_transform = tf.lookupTransform (target_frame, scan_in.header.frame_id, start_time);
     geometry_msgs::TransformStamped end_transform = tf.lookupTransform (target_frame, scan_in.header.frame_id, end_time);


### PR DESCRIPTION
In one of our use cases, a component sometimes needs to publish empty [LaserScan](http://docs.ros.org/api/sensor_msgs/html/msg/LaserScan.html) messages (with no elements in the `ranges[]` field) because all original scan points had been filtered out.

This would cause exceptions due to a negative `ros::Duration` in the `transformLaserScanToPointCloud_(...)` methods (called by RViz) due to a missing `empty()` check. The problem was introduced in #6. This pull request fixes that.
