### PR TITLE
[ros2] fix eigen dependency name

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,12 +20,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>Eigen3</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2</build_depend>
 
-  <exec_depend>Eigen3</exec_depend>
+  <exec_depend>eigen</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>tf2</exec_depend>


### PR DESCRIPTION
the Eigen3 key doesn't exist in rosdep.
This PR replaces it with `eigen`: https://github.com/ros/rosdistro/blob/3993a03516bc466e5942c0f726b10dac3def60ca/rosdep/base.yaml#L614