### PR TITLE
Add dependency on tf2 for downstream packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ catkin_python_setup()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES laser_geometry
+  CATKIN_DEPENDS tf tf2
   DEPENDS Boost EIGEN3
 )
 

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,7 @@
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf</depend>
+  <depend>tf2</depend>
 
   <exec_depend>python-numpy</exec_depend>
 


### PR DESCRIPTION
This probably should have been added in #11. I have no idea how this is working on Ubuntu, but it breaks for me when building `costmap_2d`, which fails to find tf/tf2 includes when including `laser_geometry/laser_geometry.h`.