### PR TITLE
Added PointCloud1 support

### DIFF
--- a/include/laser_geometry/laser_geometry.hpp
+++ b/include/laser_geometry/laser_geometry.hpp
@@ -36,10 +36,11 @@
 #include <sstream>
 #include <string>
 
-#include <Eigen/Core>  // NOLINT (cpplint cannot handle include order here)
+#include <eigen3/Eigen/Core>  // NOLINT (cpplint cannot handle include order here)
 
 #include "tf2/buffer_core.h"
 #include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/point_cloud.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "laser_geometry/visibility_control.hpp"
 
@@ -102,6 +103,30 @@ public:
   LaserProjection()
   : angle_min_(0), angle_max_(0) {}
 
+  //! Project a sensor_msgs::msg::LaserScan into a sensor_msgs::msg::PointCloud
+    /*!
+    * Project a single laser scan from a linear array into a 3D
+    * point cloud.  The generated cloud will be in the same frame
+    * as the original laser scan.
+    *
+    * \param scan_in The input laser scan
+    * \param cloud_out The output point cloud
+    * \param range_cutoff An additional range cutoff which can be
+    *   applied to discard everything above it.
+    *   Defaults to -1.0, which means the laser scan max range.
+    * \param channel_option An OR'd set of channels to include.
+    *   Options include: channel_option::Default,
+    *   channel_option::Intensity, channel_option::Index,
+    *   channel_option::Distance, channel_option::Timestamp.
+    */
+    void projectLaser (const sensor_msgs::msg::LaserScan & scan_in,
+                        sensor_msgs::msg::PointCloud& cloud_out,
+                        double range_cutoff = -1.0,
+                        int channel_options = channel_option::Default)
+    {
+    return projectLaser_ (scan_in, cloud_out, range_cutoff, false, channel_options);
+    }
+
   // Project a sensor_msgs::msg::LaserScan into a sensor_msgs::msg::PointCloud2
   /*!
    * Project a single laser scan from a linear array into a 3D
@@ -127,6 +152,38 @@ public:
   {
     projectLaser_(scan_in, cloud_out, range_cutoff, channel_options);
   }
+
+  
+    //! Transform a sensor_msgs::msg::LaserScan into a sensor_msgs::msg::PointCloud in target frame
+    /*!
+    * Transform a single laser scan from a linear array into a 3D
+    * point cloud, accounting for movement of the laser over the
+    * course of the scan.  In order for this transform to be
+    * meaningful at a single point in time, the target_frame must
+    * be a fixed reference frame.  See the tf documentation for
+    * more information on fixed frames.
+    *
+    * \param target_frame The frame of the resulting point cloud
+    * \param scan_in The input laser scan
+    * \param cloud_out The output point cloud
+    * \param tf a tf::Transformer object to use to perform the
+    *   transform
+    * \param range_cutoff An additional range cutoff which can be
+    *   applied to discard everything above it.
+    * \param channel_option An OR'd set of channels to include.
+    *   Options include: channel_option::Default,
+    *   channel_option::Intensity, channel_option::Index,
+    *   channel_option::Distance, channel_option::Timestamp.
+    */
+    void transformLaserScanToPointCloud (const std::string& target_frame,
+                                        const sensor_msgs::msg::LaserScan& scan_in,
+                                        sensor_msgs::msg::PointCloud& cloud_out,
+                                        tf2::BufferCore & tf,
+                                        double range_cutoff,
+                                        int channel_options = channel_option::Default)
+    {
+    return transformLaserScanToPointCloud_ (target_frame, cloud_out, scan_in, tf, range_cutoff, channel_options);
+    }
 
   // Transform a sensor_msgs::msg::LaserScan into a sensor_msgs::msg::PointCloud2 in target frame
   /*!
@@ -164,12 +221,28 @@ public:
   }
 
 private:
+    
+  //! Internal hidden representation of projectLaser
+  void projectLaser_ (const sensor_msgs::msg::LaserScan& scan_in,
+    sensor_msgs::msg::PointCloud& cloud_out,
+    double range_cutoff,
+    bool preservative,
+    int channel_options);
+
   // Internal hidden representation of projectLaser
   void projectLaser_(
     const sensor_msgs::msg::LaserScan & scan_in,
     sensor_msgs::msg::PointCloud2 & cloud_out,
     double range_cutoff,
     int channel_options);
+
+  //! Internal hidden representation of transformLaserScanToPointCloud
+      void transformLaserScanToPointCloud_ (const std::string& target_frame,
+                                            sensor_msgs::msg::PointCloud& cloud_out,
+                                            const sensor_msgs::msg::LaserScan& scan_in,
+                                            tf2::BufferCore & tf,
+                                            double range_cutoff,
+                                            int channel_options);
 
   // Internal hidden representation of transformLaserScanToPointCloud2
   void transformLaserScanToPointCloud_(


### PR DESCRIPTION
Copied PointCloud1 related functionalities from indigo branch and ported it to ros2, for laser_assembler package.
As per comment of jonbinney on laser_assembler package as follows
"It would be good to keep support for both. It looks like ROS2 still has a PointCloud message: https://github.com/ros2/common_interfaces/tree/master/sensor_msgs/msg

The PointCloud message is simpler to use for people who aren't using PCL, since the PointCloud2 is a big binary blob that you have to manually parse."

Could you please review the code and give your feedback ?