### PR TITLE
[Windows][indigo] Fix run_tests build breaks on Windows\MSVC build

### DIFF
--- a/test/projection_test.cpp
+++ b/test/projection_test.cpp
@@ -28,7 +28,9 @@
  */
 
 #include <gtest/gtest.h>
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 #include "laser_geometry/laser_geometry.h"
 #include "sensor_msgs/PointCloud.h"


### PR DESCRIPTION
Conditionally include `<sys/time.h>` since it doesn't exist on Windows\MSVC SDK.