### PR TITLE
Make rostest headers available to projection_test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ add_library(laser_geometry src/laser_geometry.cpp)
 target_link_libraries(laser_geometry ${Boost_LIBRARIES} ${tf_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
   catkin_add_gtest(projection_test test/projection_test.cpp)
+  target_include_directories(projection_test PRIVATE ${rostest_INCLUDE_DIRS})
   target_link_libraries(projection_test laser_geometry)
 
   catkin_add_nosetests(test/projection_test.py)


### PR DESCRIPTION
Similar to ros/geometry#195, this fixes a build failure when building the `tests` target. This would likely be seen in the next CI run of ros-infrastructure/ros_buildfarm_config#151

To reproduce this failure locally:

```
catkin_make_isolated --cmake-args -DCATKIN_ENABLE_TESTING=1 --make-args tests
```