### PR TITLE
Choose python version based on what ros is using

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -26,7 +26,8 @@
   <depend>tf</depend>
   <depend>tf2</depend>
 
-  <exec_depend>python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>laser_geometry</name>
   <version>1.6.4</version>
   <description>


### PR DESCRIPTION
@sloretz i tried using the syntax from http://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_dependencies_in_your_package.xml but get errors:

```
$ rosdep install --from-path . --rosdistro=noetic 
Error(s) in package '/home/jbinney/ws/laser_filters/src/laser_geometry/./package.xml':
Error(s):
- The "exec_depend" tag must not have the following attributes: condition
- The "exec_depend" tag must not have the following attributes: condition
```
