### PR TITLE
Added transformLaserScanToPointCloud() version utilizing fixed frame.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED
         sensor_msgs
         tf
         tf2
+        tf2_geometry_msgs
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)

--- a/include/laser_geometry/laser_geometry.h
+++ b/include/laser_geometry/laser_geometry.h
@@ -292,6 +292,40 @@ namespace laser_geometry
         transformLaserScanToPointCloud_(target_frame, scan_in, cloud_out, tf, range_cutoff, channel_options);
       }
 
+      //! Transform a sensor_msgs::LaserScan into a sensor_msgs::PointCloud2 in target frame
+      /*!
+       * Transform a single laser scan from a linear array into a 3D
+       * point cloud, accounting for movement of the laser over the
+       * course of the scan.  This version uses an intermediate fixed
+       * frame, which enables transformation into a moving frame,
+       * including transformation to the source frame at the
+       * beginning of the scan.
+       *
+       * \param target_frame The frame of the resulting point cloud
+       * \param scan_in The input laser scan
+       * \param cloud_out The output point cloud
+       * \param fixed_frame The intermediate fixed frame for transformation
+       * \param tf a tf2::BufferCore object to use to perform the
+       *   transform
+       * \param range_cutoff An additional range cutoff which can be
+       *   applied to discard everything above it.
+       *   Defaults to -1.0, which means the laser scan max range.
+       * \param channel_option An OR'd set of channels to include.
+       *   Options include: channel_option::Default,
+       *   channel_option::Intensity, channel_option::Index,
+       *   channel_option::Distance, channel_option::Timestamp.
+       */
+      void transformLaserScanToPointCloud(const std::string &target_frame,
+                                          const sensor_msgs::LaserScan &scan_in,
+                                          sensor_msgs::PointCloud2 &cloud_out,
+                                          const std::string &fixed_frame,
+                                          tf2::BufferCore &tf,
+                                          double range_cutoff = -1.0,
+                                          int channel_options = channel_option::Default)
+      {
+        transformLaserScanToPointCloud_(target_frame, scan_in, cloud_out, fixed_frame, tf, range_cutoff, channel_options);
+      }
+
     protected:
 
       //! Internal protected representation of getUnitVectors
@@ -340,6 +374,15 @@ namespace laser_geometry
       void transformLaserScanToPointCloud_ (const std::string &target_frame,
                                             const sensor_msgs::LaserScan &scan_in,
                                             sensor_msgs::PointCloud2 &cloud_out,
+                                            tf2::BufferCore &tf,
+                                            double range_cutoff,
+                                            int channel_options);
+
+      //! Internal hidden representation of transformLaserScanToPointCloud2
+      void transformLaserScanToPointCloud_ (const std::string &target_frame,
+                                            const sensor_msgs::LaserScan &scan_in,
+                                            sensor_msgs::PointCloud2 &cloud_out,
+                                            const std::string &fixed_frame,
                                             tf2::BufferCore &tf,
                                             double range_cutoff,
                                             int channel_options);

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,8 @@
   <depend>tf</depend>
   <depend>tf2</depend>
 
+  <build_depend>tf2_geometry_msgs</build_depend>
+
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
 


### PR DESCRIPTION
Resurrection of https://github.com/ros-perception/laser_geometry/pull/25. I also added a simple test verifying the functionality. This PR is super-important for mobile robots.

The code could be even more simplified by adding build-time dependency on `tf2_geometry_msgs`. Would that be okay? It would not need to be build-export or exec dependency.