### PR TITLE
increase test timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(projection_test
     test/projection_test.cpp
-    TIMEOUT 180)
+    TIMEOUT 240)
   if(TARGET projection_test)
     target_link_libraries(projection_test laser_geometry)
   endif()


### PR DESCRIPTION
Depending on the performance of the test machine the `projection_test` still times out sometimes: e.g. https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1698/testReport/(root)/projectroot/projection_test/ https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1695/testReport/(root)/projectroot/projection_test/

In other builds it took 156s which is not far away from the current timeout: https://ci.ros2.org/view/nightly/job/nightly_osx_debug/1696/