### PR TITLE
Handle FindEigen3 module's differing definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ find_package(catkin REQUIRED
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 find_package(Eigen3 REQUIRED)
+# Handle FindEigen3 module's differing definitions
+if(NOT DEFINED EIGEN3_INCLUDE_DIRS AND DEFINED EIGEN3_INCLUDE_DIR)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
 catkin_python_setup()
 
@@ -27,7 +31,7 @@ catkin_package(
 include_directories(include
     ${catkin_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIR}
+    ${EIGEN3_INCLUDE_DIRS}
 )
 
 add_library(laser_geometry src/laser_geometry.cpp)


### PR DESCRIPTION
The `FindEigen3.cmake` CMake module sets `EIGEN3_INCLUDE_DIR` instead of `EIGEN3_INCLUDE_DIRS`. At the moment, Ubuntu only includes the `Eigen3Config.cmake` config, while Fedora includes both files. CMake appears to give precedence to the module over the config, so the config never gets processed.

Alternatively, we could pass `NO_MODULE` to the `find_package` call, but this would fail on systems that ONLY have the module, though I'm not aware of any such distributions.

A similar change [was applied to rviz2](https://github.com/ros2/rviz/pull/370).

In the current code, even when `Eigen3Config.cmake` is used and `EIGEN3_INCLUDE_DIR` is referenced, a build warning comes out of catkin:
```
CMake Warning at install/share/catkin/cmake/catkin_package.cmake:166 (message):
  catkin_package() DEPENDS on 'EIGEN3' but neither 'EIGEN3_INCLUDE_DIRS' nor
  'EIGEN3_LIBRARIES' is defined.
Call Stack (most recent call first):
  install/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)
  CMakeLists.txt:23 (catkin_package)
```

This change should also resolve that warning.