### PR TITLE
Updated Eigen library include

### DIFF
--- a/include/laser_geometry/laser_geometry.hpp
+++ b/include/laser_geometry/laser_geometry.hpp
@@ -36,7 +36,7 @@
 #include <sstream>
 #include <string>
 
-#include <Eigen/Core>  // NOLINT (cpplint cannot handle include order here)
+#include <eigen3/Eigen/Eigen> // NOLINT (cpplint cannot handle include order here)
 
 #include "tf2/buffer_core.h"
 #include "sensor_msgs/msg/laser_scan.hpp"


### PR DESCRIPTION
Updated the include call of Eigen3 lib for Ubuntu 20.04 libeigen3-dev version 3.3.7-2 to prevent error.