### PR TITLE
Fix building on running on Windows Debug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_pytest REQUIRED)
 
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -71,7 +70,6 @@ if(BUILD_TESTING)
   ament_uncrustify()
 
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(ament_cmake_gmock REQUIRED)
 
   ament_add_gtest(projection_test
     test/projection_test.cpp
@@ -80,10 +78,25 @@ if(BUILD_TESTING)
     target_link_libraries(projection_test laser_geometry)
   endif()
 
+  # Python test
+  # Provides PYTHON_EXECUTABLE_DEBUG
+  find_package(python_cmake_module REQUIRED)
+  find_package(PythonExtra REQUIRED)
+
+  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+  if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+  endif()
+
+  find_package(ament_cmake_pytest REQUIRED)
+
   ament_add_pytest_test(projection test/projection_test.py
     TIMEOUT 120
+    PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
     WERROR ON
   )
+
+  set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,6 @@ if(BUILD_TESTING)
   ament_add_pytest_test(projection test/projection_test.py
     TIMEOUT 120
     PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
-    WERROR ON
   )
 
   set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
   <url>http://ros.org/wiki/laser_geometry</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_pytest</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
@@ -36,20 +35,20 @@
 
   <build_export_depend>eigen</build_export_depend>
 
+  <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>sensor_msgs_py</exec_depend>
   <exec_depend>tf2</exec_depend>
-
-  <exec_depend>ament_cmake</exec_depend>
 
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_cmake_uncrustify</test_depend>
-  <test_depend>rclpy</test_depend>
-  <test_depend>sensor_msgs_py</test_depend>
+  <test_depend>python_cmake_module</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
+; Needed to suppress warnings from pytest about the default junit_family
 [pytest]
 junit_family=xunit2

--- a/src/laser_geometry/laser_geometry.py
+++ b/src/laser_geometry/laser_geometry.py
@@ -38,11 +38,11 @@ class LaserProjection:
     """
     A class to Project Laser Scan
 
-    This calls will project laser scans into point clouds. It caches
+    This class will project laser scans into point clouds. It caches
     unit vectors between runs (provided the angular resolution of
     your scanner is not changing) to avoid excess computation.
 
-    By default all range values less thatn the scanner min_range,
+    By default all range values less than the scanner min_range or
     greater than the scanner max_range are removed from the generated
     point cloud, as these are assumed to be invalid.
 

--- a/test/projection_test.py
+++ b/test/projection_test.py
@@ -44,10 +44,10 @@ def test_project_laser():
     tolerance = 6 # decimal places
     projector = LaserProjection()
 
-    ranges = [-1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 100.0]
-    intensities = np.arange(1.0, 6.0).tolist()
+    ranges = [-1.0, 1.0, 5.0, 100.0]
+    intensities = np.arange(1.0, 4.0).tolist()
 
-    min_angles = -np.pi / np.array([1.0, 1.5, 2.0, 4.0, 8.0])
+    min_angles = -np.pi / np.array([1.0, 1.5, 8.0])
     max_angles = -min_angles
 
     angle_increments = np.pi / np.array([180., 360., 720.])
@@ -64,32 +64,6 @@ def test_project_laser():
                 angle_min, angle_max, angle_increment, scan_time)
         except BuildScanException:
             assert (angle_max - angle_min)/angle_increment <= 0
-
-        cloud_out = projector.projectLaser(scan, -1.0,
-                LaserProjection.ChannelOption.INDEX)
-        assert len(cloud_out.fields) == 4, \
-                "PointCloud2 with channel INDEX: fields size != 4"
-
-        cloud_out = projector.projectLaser(scan, -1.0,
-                LaserProjection.ChannelOption.INTENSITY)
-        assert len(cloud_out.fields) == 4, \
-                "PointCloud2 with channel INDEX: fields size != 4"
-
-        cloud_out = projector.projectLaser(scan, -1.0)
-        assert len(cloud_out.fields) == 5, \
-                "PointCloud2 with channel INDEX: fields size != 5"
-        cloud_out = projector.projectLaser(scan, -1.0,
-                LaserProjection.ChannelOption.INTENSITY |
-                LaserProjection.ChannelOption.INDEX)
-        assert len(cloud_out.fields) == 5, \
-                "PointCloud2 with channel INDEX: fields size != 5"
-
-        cloud_out = projector.projectLaser(scan, -1.0,
-                LaserProjection.ChannelOption.INTENSITY |
-                LaserProjection.ChannelOption.INDEX |
-                LaserProjection.ChannelOption.DISTANCE)
-        assert len(cloud_out.fields) == 6, \
-                "PointCloud2 with channel INDEX: fields size != 6"
 
         cloud_out = projector.projectLaser(scan, -1.0,
                 LaserProjection.ChannelOption.INTENSITY |
@@ -153,4 +127,3 @@ def test_project_laser():
 
 if __name__ == '__main__':
     pytest.main()
-


### PR DESCRIPTION
In particular, we need to set the python executable properly
when running on Windows Debug.  While we are in here, we also
fix up some dependencies in the package.xml and CMakeLists.txt.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix up the Windows Debug failures we are seeing after #80 was merged: https://ci.ros2.org/view/nightly/job/nightly_win_deb/2099/testReport/junit/(root)/laser_geometry/___/

@jonbinney FYI.