### PR TITLE
Fix Duration casting issue leading to no undistortion

### DIFF
--- a/src/laser_geometry.cpp
+++ b/src/laser_geometry.cpp
@@ -427,8 +427,8 @@ void LaserProjection::transformLaserScanToPointCloud_(
   TIME end_time = scan_in.header.stamp;
   // TODO(anonymous): reconcile all the different time constructs
   if (!scan_in.ranges.empty()) {
-    end_time = end_time + rclcpp::Duration(
-      static_cast<int>((scan_in.ranges.size() - 1) * scan_in.time_increment), 0);
+    end_time = start_time + rclcpp::Duration::from_seconds(
+      (scan_in.ranges.size() - 1) * scan_in.time_increment);
   }
 
   std::chrono::nanoseconds start(start_time.nanoseconds());

--- a/src/laser_geometry.cpp
+++ b/src/laser_geometry.cpp
@@ -428,7 +428,7 @@ void LaserProjection::transformLaserScanToPointCloud_(
   // TODO(anonymous): reconcile all the different time constructs
   if (!scan_in.ranges.empty()) {
     end_time = start_time + rclcpp::Duration::from_seconds(
-      (scan_in.ranges.size() - 1) * scan_in.time_increment);
+      static_cast<double>(scan_in.ranges.size() - 1) * static_cast<double>(scan_in.time_increment));
   }
 
   std::chrono::nanoseconds start(start_time.nanoseconds());


### PR DESCRIPTION
The end time of the LaserScan was not calculated correctly due to a casting error:
the scan duration (in seconds) was cast to int. This lead it being 0 most times and prevented the correct laser end pose from being retrieved from the TF Buffer.