### PR TITLE
Reduce boost and eigen dependency scope

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,17 +24,19 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <depend>angles</depend>
-  <depend>boost</depend>
-  <depend>eigen</depend>
   <depend>roscpp</depend>
   <depend>sensor_msgs</depend>
   <depend>tf</depend>
   <depend>tf2</depend>
 
+  <build_depend>eigen</build_depend>
+  <build_depend>libboost-dev</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
+  <exec_depend>libboost-thread<exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -36,7 +36,7 @@
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>
-  <exec_depend>libboost-thread<exec_depend>
+  <exec_depend>libboost-thread</exec_depend>
 
   <test_depend>rosunit</test_depend>
 </package>


### PR DESCRIPTION
`<depend>boost</depend>` pulls in far too much and `eigen` is header-only, so not needed during runtime.