### PR TITLE
[ros-o] patch sets melodic+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(laser_geometry)
 
-set(CMAKE_CXX_STANDARD 11)
-
 find_package(catkin REQUIRED
     COMPONENTS
         angles

--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
   <depend>tf2</depend>
 
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>rostest</build_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
The pr targets kinetic, but these patches (which are mandatory for [ros-o](https://github.com/ros-o/ros-o)) are compatible from melodic+, so you will want a new `melodic-devel` or `noetic-devel` branch.