### PR TITLE
Update laser_geometry to C++17.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 project(laser_geometry)
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
The main reason to do this is so that we can compile laser_geometry with the clang static analyzer.  As of clang++-14 (what is in Ubuntu 22.04), the default still seems to be C++14, so we need to specify C++17 so that new things in the rclcpp headers work properly.

Further, due to reasons I don't fully understand, I needed to set CMAKE_CXX_STANDARD_REQUIRED in order for clang to really use that version.  So set this as well.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>