### PR TITLE
Stop using python_cmake_module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,24 +81,11 @@ if(BUILD_TESTING)
     target_link_libraries(projection_test laser_geometry rclcpp::rclcpp)
   endif()
 
-  # Python test
-  # Provides PYTHON_EXECUTABLE_DEBUG
-  find_package(python_cmake_module REQUIRED)
-  find_package(PythonExtra REQUIRED)
-
-  set(_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
-  if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-  endif()
-
   find_package(ament_cmake_pytest REQUIRED)
 
   ament_add_pytest_test(projection test/projection_test.py
     TIMEOUT 120
-    PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}"
   )
-
-  set(PYTHON_EXECUTABLE "${_PYTHON_EXECUTABLE}")
 endif()
 
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>

--- a/package.xml
+++ b/package.xml
@@ -47,7 +47,6 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>python_cmake_module</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
We really don't need it anymore, and can just use the builtin find_package(Python3).

This must be merged before https://github.com/ros2/ros2/pull/1524 ; see that pull request for more information about this change.