### PR TITLE
[ROS-O] fix package.xml bugs and compatibility with modern systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(laser_geometry)
 
-set(CMAKE_CXX_STANDARD 11)
-
 find_package(catkin REQUIRED
     COMPONENTS
         angles

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-thread-dev</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+  <build_depend>rostest</build_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>
   <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,12 @@
   <build_depend>libboost-dev</build_depend>
   <build_depend>libboost-thread-dev</build_depend>
   <build_depend>tf2_geometry_msgs</build_depend>
+
+  <build_export_depend>eigen</build_export_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
+  <build_export_depend>libboost-thread-dev</build_export_depend>
+  <build_export_depend>tf2_geometry_msgs</build_export_depend>
+
   <build_depend>rostest</build_depend>
 
   <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</exec_depend>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
@jonbinney I'll pick you up [on your promise](https://github.com/ros-perception/laser_assembler/pull/32#issuecomment-2273673757) here. :sunglasses: 

Concerning the patches:
- missing build_export declarations was introduced with the last merged patch #87 
- rostest was plainly missing
- the setuptools change works for a very long time already, no concern here
- the c++11 declaration breaks modern logcxx (and by now also other major libraries) requiring c++14 (and 17).